### PR TITLE
Remove Ubuntu 12.04 and SLES 12.1 builders

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -115,7 +115,6 @@ builder_simple_props = {
 # Builder properties are a combination of exactly one set of properties from each
 # of the above groups.
 debiansys_props = merge_dicts(global_props, with_zfs, builder_simple_props)
-susesys_props = merge_dicts(global_props, with_zfs, builder_default_props)
 default_props = merge_dicts(global_props, with_zfs_ldiskfs, builder_default_props)
 
 #### BUILDSLAVES
@@ -135,20 +134,6 @@ CentOS_7_2_slaves = [
     ) for i in range(0, numSlaves)
 ]
 
-SLES_12_1_slaves = [
-    LustreEC2SuseSlave(
-        name="SUSE-12.1-x86_64-buildslave%s" % (str(i+1)),
-        ami="ami-6b77870b"
-    ) for i in range(0, numSlaves)
-]
-
-Ubuntu_12_04_slaves = [
-    LustreEC2Slave(
-        name="Ubuntu-12.04-x86_64-buildslave%s" % (str(i+1)),
-        ami="ami-55788835"
-    ) for i in range(0, numSlaves)
-]
-
 Ubuntu_14_04_slaves = [
     LustreEC2Slave(
         name="Ubuntu-14.04-x86_64-buildslave%s" % (str(i+1)),
@@ -156,7 +141,7 @@ Ubuntu_14_04_slaves = [
     ) for i in range(0, numSlaves)
 ]
 
-all_slaves = CentOS_6_7_slaves + CentOS_7_2_slaves + SLES_12_1_slaves + Ubuntu_12_04_slaves + Ubuntu_14_04_slaves
+all_slaves = CentOS_6_7_slaves + CentOS_7_2_slaves + Ubuntu_14_04_slaves
 
 ### BUILDERS
 builders = [
@@ -173,20 +158,6 @@ builders = [
         slavenames=[slave.name for slave in CentOS_7_2_slaves],
         tags=["Build"],
         properties=default_props,
-    ),
-    LustreBuilderConfig(
-        name="SLES 12.1 x86_64 (BUILD)",
-        factory=build_factory,
-        slavenames=[slave.name for slave in SLES_12_1_slaves],
-        tags=["Build"],
-        properties=susesys_props,
-    ),
-    LustreBuilderConfig(
-        name="Ubuntu 12.04 x86_64 (BUILD)",
-        factory=build_factory,
-        slavenames=[slave.name for slave in Ubuntu_12_04_slaves],
-        tags=["Build"],
-        properties=debiansys_props,
     ),
     LustreBuilderConfig(
         name="Ubuntu 14.04 x86_64 (BUILD)",


### PR DESCRIPTION
For the time being, we need to remove the SLES 12.1 and Ubuntu 12.04 builders.

Signed-off-by: Giuseppe Di Natale dinatale2@llnl.gov
