### PR TITLE
Send bash xtrace output to stdout

### DIFF
--- a/scripts/bb-build-lustre-pkg.sh
+++ b/scripts/bb-build-lustre-pkg.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
+BASH_XTRACEFD=1
 set -x
 
 VERBOSE=0

--- a/scripts/bb-build-lustre-srpm.sh
+++ b/scripts/bb-build-lustre-srpm.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
+BASH_XTRACEFD=1
 set -x
 
 VERBOSE=0

--- a/scripts/bb-build-zfs-pkg.sh
+++ b/scripts/bb-build-zfs-pkg.sh
@@ -9,6 +9,7 @@ else
    exit 0
 fi
 
+BASH_XTRACEFD=1
 set -x
 
 VERBOSE=0


### PR DESCRIPTION
Use BASH_XTRACEFD to send bash's "set -x" tracing output
to stdout rather than the default of stderr.  Buildbot
highlights text on stderr in red assuming that they are warnings.
It would be nice to reserve that for real warnings so we don't
get in the habit of ignoring the red text.
