### PR TITLE
Use correct flags to enable/disable ldiskfs and zfs.

### DIFF
--- a/scripts/bb-build-lustre-pkg.sh
+++ b/scripts/bb-build-lustre-pkg.sh
@@ -3,7 +3,7 @@ set -x
 
 VERBOSE=0
 withzfs="--without-zfs"
-withldiskfs="--without-ldiskfs"
+withldiskfs="--disable-ldiskfs"
 MAKE_FLAGS=""
 
 message () {
@@ -25,7 +25,7 @@ while getopts vlzm: FLAG; do
         withzfs="--with-zfs"
         ;;
       l)
-        withldiskfs="--with-ldiskfs"
+        withldiskfs="--enable-ldiskfs"
         ;;
       m)
         MAKE_FLAGS="$OPTARG"


### PR DESCRIPTION
Corrected scripts/bb-build-lustre-pkg.sh to use the correct flags to enable or disable ldiskfs. The corrrect flags are --enable-ldiskfs/--disable-ldiskfs.

This closes #9.

Signed-off-by: Giuseppe Di Natale dinatale2@llnl.gov
