### PR TITLE
Create a tarball builder.

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -51,7 +51,8 @@ c['titleURL'] = "http://" + gerrit_url
 c['buildbotURL'] = "http://%s:%s" % (bb_master_url, bb_web_port)
 
 ####### FACTORIES
-build_factory = getBuildFactory(gerrit_repo_http)
+build_factory = createBuildFactory(gerrit_repo_http)
+tarball_factory = createTarballFactory(gerrit_repo_http)
 
 ####### BUILDER PROPERTIES
 
@@ -73,6 +74,7 @@ def merge_dicts(*args):
 # of scripts to execute and which spl and zfs tags to boot strap with.
 global_props = {
     "bburl"       :      bb_url,
+    "bbmaster"    :      bb_master_url,
     "installdeps" :      "no",
     "spltag"      :      "spl-0.6.5.4",
     "zfstag"      :      "zfs-0.6.5.4",
@@ -120,6 +122,14 @@ default_props = merge_dicts(global_props, with_zfs_ldiskfs, builder_default_prop
 #### BUILDSLAVES
 numSlaves = 3  # number of slaves per builder
 
+tarball_slaves = [
+    LustreEC2Slave(
+        name="CentOS-7.2-x86_64-tarballslave",
+        ami="ami-53c33e33",
+        build_wait_timeout=5*60*60
+    )
+]
+
 CentOS_6_7_slaves = [
     LustreEC2Slave(
         name="CentOS-6.7-x86_64-buildslave%s" % (str(i+1)),
@@ -141,10 +151,17 @@ Ubuntu_14_04_slaves = [
     ) for i in range(0, numSlaves)
 ]
 
-all_slaves = CentOS_6_7_slaves + CentOS_7_2_slaves + Ubuntu_14_04_slaves
+all_slaves = CentOS_6_7_slaves + CentOS_7_2_slaves + Ubuntu_14_04_slaves + tarball_slaves
 
 ### BUILDERS
 builders = [
+    LustreBuilderConfig(
+        name="CentOS 7.2 x86_64 (TARBALL)",
+        factory=tarball_factory,
+        slavenames=[slave.name for slave in tarball_slaves],
+        tags=["Build"],
+        properties=default_props,
+    ),
     LustreBuilderConfig(
         name="CentOS 6.7 x86_64 (BUILD)",
         factory=build_factory,


### PR DESCRIPTION
Introduction of a new builder to build tarballs.
The new builder will generate a tarball and upload them to the
buildbot master. This is the first phase of the bandwidth
reduction refactoring (#12).

opensfs/buildbot#6 should be accepted before accepting this
pull request.

Signed-off-by: Giuseppe Di Natale dinatale2@llnl.gov
