### PR TITLE
Reduce bandwidth usage when running builds.

### DIFF
--- a/master/lustrefactory.py
+++ b/master/lustrefactory.py
@@ -6,25 +6,28 @@ from buildbot.steps.source.gerrit import Gerrit
 from buildbot.steps.shell import ShellCommand
 from buildbot.steps.shell import Configure
 from buildbot.steps.shell import SetPropertyFromCommand 
-from buildbot.steps.transfer import FileUpload
+from buildbot.steps.transfer import FileUpload, FileDownload
 from buildbot.steps.trigger import Trigger
 from buildbot.status.results import SUCCESS 
 from buildbot.status.results import FAILURE 
 from buildbot.status.results import SKIPPED 
 from buildbot.status.results import WARNINGS
 
-def do_step_build(step, name):
+def do_step_if_value(step, name, value):
     props = step.build.getProperties()
-    if props.hasProperty(name) and props[name] == "yes":
+    if props.hasProperty(name) and props[name] == value:
         return True
     else:
         return False
 
 def do_step_zfs(step):
-    return do_step_build(step, 'buildzfs')
+    return do_step_if_value(step, 'buildzfs', 'yes')
 
 def do_step_installdeps(step):
-    return do_step_build(step, 'installdeps')
+    return do_step_if_value(step, 'installdeps', 'yes')
+
+def do_step_rpmbuild(step):
+    return do_step_if_value(step, 'buildstyle', 'srpm')
 
 def hide_if_skipped(results, step):
     return results == SKIPPED
@@ -52,6 +55,65 @@ def buildzfsCommand(props):
     zfstag = props.getProperty('zfstag')
     if zfstag:
         args.extend(["-z", zfstag])
+
+    return args
+
+@util.renderer
+def configureCmd(props):
+    args = ["./configure"]
+    style = props.getProperty('buildstyle')
+
+    if style == "deb" or style == "rpm":
+        with_zfs = props.getProperty('withzfs')
+        if with_zfs and with_zfs == "yes":
+            args.extend(["--with-zfs"])
+        else:
+            args.extend(["--without-zfs"])
+
+        with_ldiskfs = props.getProperty('withldiskfs')
+        if with_ldiskfs and with_ldiskfs == "yes":
+            args.extend(["--enable-ldiskfs"])
+        else:
+            args.extend(["--disable-ldiskfs"])
+    elif style == "srpm":
+        args.extend(["--enable-dist"])
+
+    return args
+
+@util.renderer
+def makeCmd(props):
+    args = ["sh", "-c"]
+    style = props.getProperty('buildstyle')
+
+    if style == "srpm":
+        args.extend(["make -j$(nproc) srpm"])
+    elif style == "deb":
+        args.extend(["make -j$(nproc) debs"])
+    elif style == "rpm":
+        args.extend(["make -j$(nproc) rpms"])
+    else:
+        args.extend(["make -j$(nproc)"])
+
+    return args
+
+@util.renderer
+def rpmbuildCmd(props):
+    args = ["sh", "-c"] 
+    style = props.getProperty('buildstyle')
+    zfsArg = "--without zfs"
+    ldiskfsArg = "--without ldiskfs"
+
+    if style == "srpm":
+        with_zfs = props.getProperty('withzfs')
+        if with_zfs and with_zfs == "yes":
+            zfsArg = "--with zfs"
+
+        with_ldiskfs = props.getProperty('withldiskfs')
+        if with_ldiskfs and with_ldiskfs == "yes":
+            ldiskfsArg = "--with ldiskfs"
+
+    cmd = "rpmbuild --rebuild %s %s lustre-*.src.rpm" % (zfsArg, ldiskfsArg)
+    args.extend([cmd])
 
     return args
 
@@ -132,16 +194,33 @@ def createTarballFactory(gerrit_repo):
         masterdest=util.Interpolate("public_html/buildproducts/%(prop:event.change.number)s/%(prop:event.patchSet.number)s/%(prop:tarball)s"),
         url=util.Interpolate("http://%(prop:bbmaster)s/buildproducts/%(prop:event.change.number)s/%(prop:event.patchSet.number)s/%(prop:tarball)s")))
 
+    # trigger our builders to generate packages
+    bf.addStep(Trigger(
+        schedulerNames=["package-builders"],
+        set_properties={"tarball" : util.Interpolate("%(prop:tarball)s")},
+        waitForFinish=False))
+
     return bf
 
-def createBuildFactory(gerrit_repo):
-    """ Generates a build factory for a standard lustre builder.
-    Args:
-        gerrit_repo (string): Gerrit repo url
+def createPackageBuildFactory():
+    """ Generates a build factory for a lustre tarball builder.
     Returns:
-        BuildFactory: Build factory with steps for a standard lustre builder.
+        BuildFactory: Build factory with steps for a lustre builder.
     """
     bf = util.BuildFactory()
+
+    # download our tarball and extract it
+    bf.addStep(FileDownload(
+        workdir="build/lustre",
+        slavedest=util.Interpolate("%(prop:tarball)s"),
+        mastersrc=util.Interpolate("public_html/buildproducts/%(prop:event.change.number)s/%(prop:event.patchSet.number)s/%(prop:tarball)s")))
+
+    bf.addStep(ShellCommand(
+        workdir="build/lustre",
+        command=["tar", "-xvzf", util.Interpolate("%(prop:tarball)s"), "--strip-components=1"],
+        haltOnFailure=True, logEnviron=False,
+        lazylogfiles=True,
+        description=["extracting tarball"], descriptionDone=["extract tarball"]))
 
     # update dependencies
     bf.addStep(ShellCommand(
@@ -163,25 +242,43 @@ def createBuildFactory(gerrit_repo):
         description=["building spl and zfs"],
         descriptionDone=["built spl and zfs"]))
 
-    # Pull the patch from Gerrit
-    bf.addStep(Gerrit(
-        repourl=gerrit_repo, workdir="build/lustre",
-        mode="full", method="clobber", retry=[60,60], timeout=3600,
-        logEnviron=False, getDescription=True, haltOnFailure=True,
-        description=["cloning"], descriptionDone=["cloned"]))
-
     # Build Lustre 
     bf.addStep(ShellCommand(
         workdir="build/lustre",
-        command=buildCommand,
+        command=configureCmd,
         haltOnFailure=True, logEnviron=False,
         hideStepIf=hide_if_skipped,
         lazylogfiles=True,
-        decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
-        description=["building lustre"], descriptionDone=["built lustre"]))
+        description=["configuring lustre"], descriptionDone=["configure lustre"]))
+
+    bf.addStep(ShellCommand(
+        workdir="build/lustre",
+        command=makeCmd,
+        haltOnFailure=True, logEnviron=False,
+        hideStepIf=hide_if_skipped,
+        lazylogfiles=True,
+        description=["making lustre"], descriptionDone=["make lustre"]))
+
+    bf.addStep(ShellCommand(
+        workdir="build/lustre",
+        command=rpmbuildCmd,
+        haltOnFailure=True, logEnviron=False,
+        doStepIf=do_step_rpmbuild,
+        hideStepIf=hide_if_skipped,
+        lazylogfiles=True,
+        description=["rpmbuilding lustre"], descriptionDone=["rpmbuild lustre"]))
 
     # TODO: upload build products
     # Primary idea here is to upload the build products to buildbot's public html folder
     # what should go in there so far: tarball, srpm (maybe?), and build products (for the testers to download)
+
+    bf.addStep(ShellCommand(
+        workdir="build",
+        command=["sh", "-c", "rm -rf *"],
+        haltOnFailure=True, logEnviron=False,
+        lazylogfiles=True,
+        alwaysRun=True,
+        description=["cleaning up"],
+        descriptionDone=["clean up"]))
 
     return bf

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -51,7 +51,7 @@ c['titleURL'] = "http://" + gerrit_url
 c['buildbotURL'] = "http://%s:%s" % (bb_master_url, bb_web_port)
 
 ####### FACTORIES
-build_factory = createBuildFactory(gerrit_repo_http)
+build_factory = createPackageBuildFactory()
 tarball_factory = createTarballFactory(gerrit_repo_http)
 
 ####### BUILDER PROPERTIES
@@ -118,6 +118,7 @@ builder_simple_props = {
 # of the above groups.
 debiansys_props = merge_dicts(global_props, with_zfs, builder_simple_props)
 default_props = merge_dicts(global_props, with_zfs_ldiskfs, builder_default_props)
+tarball_props = global_props
 
 #### BUILDSLAVES
 numSlaves = 3  # number of slaves per builder
@@ -154,14 +155,17 @@ Ubuntu_14_04_slaves = [
 all_slaves = CentOS_6_7_slaves + CentOS_7_2_slaves + Ubuntu_14_04_slaves + tarball_slaves
 
 ### BUILDERS
-builders = [
+tarball_builders = [
     LustreBuilderConfig(
         name="CentOS 7.2 x86_64 (TARBALL)",
         factory=tarball_factory,
         slavenames=[slave.name for slave in tarball_slaves],
-        tags=["Build"],
-        properties=default_props,
+        tags=["Tarball"],
+        properties=tarball_props,
     ),
+]
+
+builders = [
     LustreBuilderConfig(
         name="CentOS 6.7 x86_64 (BUILD)",
         factory=build_factory,
@@ -187,7 +191,7 @@ builders = [
 
 test_builders = []
 
-all_builders = builders + test_builders
+all_builders = tarball_builders + builders + test_builders
 
 c['builders'] = all_builders
 
@@ -283,6 +287,9 @@ c['schedulers'] = [
             project=gerrit_project,
             branch_re=(gerrit_branch + "/*"),
             eventtype="patchset-created"),
+        builderNames=[builder.name for builder in tarball_builders]),
+    Triggerable(
+        name="package-builders",
         builderNames=[builder.name for builder in builders]),
     Try_Userpass(
         name="try-scheduler",


### PR DESCRIPTION
Phase one of the bandwidth reduction goal was to make a builder
that cloned patch sets and produced a tarball.

This is Phase two of the bandwidth reduction goal. Now that a
tarball is available, all builders should download the tarball
and perform a build from there instead of producing separate
clones.

This closes #12.

Signed-off-by: Giuseppe Di Natale dinatale2@llnl.gov
