### PR TITLE
Set EC2 spot price_multiplier to None

### DIFF
--- a/master/lustrebuildslave.py
+++ b/master/lustrebuildslave.py
@@ -88,7 +88,7 @@ runurl $BB_URL/bb-bootstrap.sh"""
                 keypair_name=ec2_default_keypair_name, security_name='LustreBuilder',
                 user_data=None, region="us-west-2", placement="a", max_builds=1, 
                 build_wait_timeout=60 * 30, spot_instance=True, max_spot_price=.08,
-                price_multiplier=1.25, **kwargs):
+                price_multiplier=None, **kwargs):
 
         self.name = name
 


### PR DESCRIPTION
Buildbot branch 0.8.13-pre-lustre now contains a backport of the
"Allow independant EC2 price_multiplier or max_spot_price usage"
branch from master.  Now price_multiplier is no longer necessary.

We set the price_multiplier to None in our configuration since
we really just want to set a max bid price regardless of historical
spot pricing.
