### PR TITLE
Publish binary packages from the build process

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -170,21 +170,21 @@ builders = [
         factory=build_factory,
         slavenames=[slave.name for slave in CentOS_6_7_slaves],
         tags=["Build"],
-        properties=default_props,
+        properties=merge_dicts(default_props, {"distro" : "centos", "distrover" : "6"}),
     ),
     LustreBuilderConfig(
         name="CentOS 7.2 x86_64 (BUILD)",
         factory=build_factory,
         slavenames=[slave.name for slave in CentOS_7_2_slaves],
         tags=["Build"],
-        properties=default_props,
+        properties=merge_dicts(default_props, {"distro" : "centos", "distrover" : "7"}),
     ),
     LustreBuilderConfig(
         name="Ubuntu 14.04 x86_64 (BUILD)",
         factory=build_factory,
         slavenames=[slave.name for slave in Ubuntu_14_04_slaves],
         tags=["Build"],
-        properties=debiansys_props,
+        properties=merge_dicts(debiansys_props, {"distro" : "ubuntu", "distrover" : "14.04"}),
     ),
 ]
 


### PR DESCRIPTION
Binary packages that are built by build slaves are now available
on the Lustre Build Bot waterfall page.

Signed-off-by: Giuseppe Di Natale dinatale2@llnl.gov
