### PR TITLE
Build a yum repository for CentOS builds

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -170,21 +170,21 @@ builders = [
         factory=build_factory,
         slavenames=[slave.name for slave in CentOS_6_7_slaves],
         tags=["Build"],
-        properties=merge_dicts(default_props, {"distro" : "centos", "distrover" : "6"}),
+        properties=merge_dicts(default_props, {"distro" : "centos", "distrover" : "6", "arch" : "x86_64"}),
     ),
     LustreBuilderConfig(
         name="CentOS 7.2 x86_64 (BUILD)",
         factory=build_factory,
         slavenames=[slave.name for slave in CentOS_7_2_slaves],
         tags=["Build"],
-        properties=merge_dicts(default_props, {"distro" : "centos", "distrover" : "7"}),
+        properties=merge_dicts(default_props, {"distro" : "centos", "distrover" : "7", "arch" : "x86_64"}),
     ),
     LustreBuilderConfig(
         name="Ubuntu 14.04 x86_64 (BUILD)",
         factory=build_factory,
         slavenames=[slave.name for slave in Ubuntu_14_04_slaves],
         tags=["Build"],
-        properties=merge_dicts(debiansys_props, {"distro" : "ubuntu", "distrover" : "14.04"}),
+        properties=merge_dicts(debiansys_props, {"distro" : "ubuntu", "distrover" : "14.04", "arch" : "x86_64"}),
     ),
 ]
 


### PR DESCRIPTION
The lustre buildbot will now build a yum repo
for all builds issued to CentOS builders. A link
to the repository is provided in the waterfall
view. A lustre.repo file is generated and made
publically available.

Signed-off-by: Giuseppe Di Natale dinatale2@llnl.gov
