### PR TITLE
Use AWS West 1 zone for EC2 slaves

### DIFF
--- a/master/lustrebuildslave.py
+++ b/master/lustrebuildslave.py
@@ -86,7 +86,7 @@ runurl $BB_URL/bb-bootstrap.sh"""
     def __init__(self, name, password=None, master='', url='', instance_type="m3.large",
                 identifier=ec2_default_access, secret_identifier=ec2_default_secret,
                 keypair_name=ec2_default_keypair_name, security_name='LustreBuilder',
-                user_data=None, region="us-west-2", placement="a", max_builds=1, 
+                user_data=None, region="us-west-1", placement="b", max_builds=1,
                 build_wait_timeout=60 * 30, spot_instance=True, max_spot_price=.08,
                 price_multiplier=None, **kwargs):
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -125,7 +125,7 @@ numSlaves = 3  # number of slaves per builder
 tarball_slaves = [
     LustreEC2Slave(
         name="CentOS-7.2-x86_64-tarballslave",
-        ami="ami-53c33e33",
+        ami="ami-89591be9",
         build_wait_timeout=5*60*60
     )
 ]
@@ -133,21 +133,21 @@ tarball_slaves = [
 CentOS_6_7_slaves = [
     LustreEC2Slave(
         name="CentOS-6.7-x86_64-buildslave%s" % (str(i+1)),
-        ami="ami-aac63bca"
+        ami="ami-3c54165c"
     ) for i in range(0, numSlaves)
 ]
 
 CentOS_7_2_slaves = [
     LustreEC2Slave(
         name="CentOS-7.2-x86_64-buildslave%s" % (str(i+1)),
-        ami="ami-53c33e33"
+        ami="ami-89591be9"
     ) for i in range(0, numSlaves)
 ]
 
 Ubuntu_14_04_slaves = [
     LustreEC2Slave(
         name="Ubuntu-14.04-x86_64-buildslave%s" % (str(i+1)),
-        ami="ami-6bc23f0b"
+        ami="ami-3d54165d"
     ) for i in range(0, numSlaves)
 ]
 


### PR DESCRIPTION
Move all AWS EC2 slaves to US West 1 zone becuase
that zone offers more stable spot instance pricing.

Signed-off-by: Giuseppe Di Natale dinatale2@llnl.gov
