### PR TITLE
Report build results to Gerrit

### DIFF
--- a/master/lustregerritstatuspush.py
+++ b/master/lustregerritstatuspush.py
@@ -1,0 +1,40 @@
+from buildbot.status.status_gerrit import GerritStatusPush
+from twisted.internet import reactor
+
+class LustreGerritStatusPush(GerritStatusPush):
+
+    def __init__(self, notify="OWNER", **kwargs):
+        self.gerrit_notify = notify
+
+        GerritStatusPush.__init__(self, **kwargs)
+
+    def sendCodeReview(self, project, revision, result):
+        gerrit_version = self.getCachedVersion()
+        if gerrit_version is None:
+            self.callWithVersion(lambda: self.sendCodeReview(project, revision,
+                                                             result))
+            return
+
+        command = self._gerritCmd("review", "--project %s" % str(project))
+
+        if self.gerrit_notify is not None:
+            command.extend(["--notify %s" % str(self.gerrit_notify)])
+
+        message = result.get('message', None)
+        if message:
+            command.append("--message '%s'" % message.replace("'", "\""))
+
+        labels = result.get('labels', None)
+        if labels:
+            assert gerrit_version
+            if gerrit_version < LooseVersion("2.6"):
+                add_label = _old_add_label
+            else:
+                add_label = _new_add_label
+
+            for label, value in labels.items():
+                command.extend(add_label(label, value))
+
+        command.append(str(revision))
+        print command
+        reactor.spawnProcess(self.LocalPP(self), command[0], command)

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -8,6 +8,7 @@ from lustrebuildslave import *
 from lustrefactory import *
 from lustregittagpoller import *
 from buildbot.status import html
+from lustregerritstatuspush import LustreGerritStatusPush
 from buildbot.status.web import authz, auth
 from buildbot.plugins import status, util
 from buildbot.schedulers.triggerable import Triggerable
@@ -49,7 +50,7 @@ c['titleURL'] = "http://" + gerrit_url
 # the 'www' entry below, but with an externally-visible host name which the 
 # buildbot cannot figure out without some help.
 
-c['buildbotURL'] = "http://%s:%s" % (bb_master_url, bb_web_port)
+c['buildbotURL'] = "http://%s/" % (bb_master_url)
 
 ####### FACTORIES
 build_factory = createPackageBuildFactory()
@@ -317,8 +318,6 @@ c['schedulers'] = [
 # pushed to these targets. buildbot/status/*.py has a variety to choose from,
 # like IRC bots.
 
-c['status'] = []
-
 authz_cfg=util.Authz(
     auth=util.BasicAuth(web_userpass),
     gracefulShutdown = False,
@@ -331,8 +330,65 @@ authz_cfg=util.Authz(
     cancelPendingBuild = 'auth',
 )
 
-c['status'].append(html.WebStatus(http_port=bb_web_port,
-    order_console_by_time=True, authz=authz_cfg))
+def lustreGerritSummaryCB(buildInfoList, results, status, arg):
+    failure = False
+    fullMessage = None
+    containsTarballBuild = False
+    msgs = []
+
+    for buildInfo in buildInfoList:
+        msg = "Builder %(name)s %(resultText)s (%(text)s)" % buildInfo
+        link = buildInfo.get('url', None)
+        if link:
+            msg += " - " + link
+        else:
+            msg += "."
+        msgs.append(msg)
+
+        # this series of builds contained the tarball builder
+        if re.search('(TARBALL)', msg):
+            containsTarballBuild = True
+
+        # if we get a result that is not a success, assume failure
+        # this may change in the future if we introduce something with warnings
+        if buildInfo['result'] != SUCCESS:
+            failure = True
+
+    # if there is more than one build info, then we want an overall status
+    if len(buildInfoList) > 1:
+        if failure:
+            overall_status = "Overall Build Status: FAIL"
+        else:
+            overall_status = "Overall Build Status: SUCCESS"
+
+        msgs = [overall_status] + msgs
+
+    # construct full message
+    # avoid only sending status messages with just the TARBALL status
+    # always send a status message on failure
+    if len(buildInfoList) > 1 or not containsTarballBuild or failure:
+        fullMessage=('\n\n'.join(msgs))
+
+    # labels are for when you want to mark something reviewed or verified
+    # if message is None, the GerritStatusPush won't send a status update
+    return dict(message=fullMessage, labels=None)
+
+c['status'] = [
+    # web status
+    html.WebStatus(
+        http_port=bb_web_port,
+        order_console_by_time=True,
+        authz=authz_cfg),
+    # push build results to gerrit
+    LustreGerritStatusPush(
+        server=gerrit_url,
+        port=gerrit_port,
+        username=gerrit_user,
+        reviewCB=None,
+        startCB=None,
+        summaryCB=lustreGerritSummaryCB,
+        summaryArg=None)
+]
 
 ####### DB URL
 


### PR DESCRIPTION
Using buildbot's GerritStatusPush object, the lustre
build farm reports the status of each build to the
appropriate change to Intel's Gerrit.

Update master.cfg with the new ZFS baseline for lustre.

This closes #26.
