### PR TITLE
Correct _dovccmd call in LustreTagPoller._getRefs

### DIFF
--- a/master/lustregittagpoller.py
+++ b/master/lustregittagpoller.py
@@ -47,7 +47,7 @@ class LustreTagPoller(GitPoller):
     def _getRefs(self):
         """Collect and parse all local references"""
 
-        d = self._dovccmd('show-ref', [])
+        d = self._dovccmd('show-ref', [], path=self.workdir)
 
         @d.addCallback
         def parseRefs(rows):

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -299,7 +299,7 @@ c['schedulers'] = [
         name="tag-changes",
         change_filter=util.ChangeFilter(
             project=gerrit_project,
-            branch_re="^refs/tags/[0-9]+\.[0-9]+\.[0-9]+(.[0-9]+)?$"),
+            branch_re="^refs/tags/[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$"),
         builderNames=[builder.name for builder in tarball_builders]),
     Triggerable(
         name="package-builders",


### PR DESCRIPTION
Correct the _dovccmd method call in LustreTagPoller's
_getRefs method. When calling the _dovccmd method, the
path should always be provided.

Signed-off-by: Giuseppe Di Natale dinatale2@llnl.gov
