### PR TITLE
Use static AMI images for builds

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -77,8 +77,9 @@ global_props = {
     "bburl"       :      bb_url,
     "bbmaster"    :      bb_master_url,
     "installdeps" :      "no",
-    "spltag"      :      "spl-0.6.5.4",
-    "zfstag"      :      "zfs-0.6.5.4",
+    "buildzfs"    :      "no",
+    "spltag"      :      "spl-0.6.5.7",
+    "zfstag"      :      "zfs-0.6.5.7",
 }
 
 # This group of properties controls which features to include when compiling lustre. 
@@ -105,12 +106,10 @@ with_zfs_ldiskfs = {
 #     - deb: autogen, configure, make debs
 #     - rpm: autogen, configure, make rpms
 builder_default_props = {
-    "buildzfs"    :      "yes",
     "buildstyle"  :      "rpm",
 }
 
 builder_simple_props = {
-    "buildzfs"    :      "yes",
     "buildstyle"  :      "simple",
 }
 
@@ -134,21 +133,21 @@ tarball_slaves = [
 CentOS_6_7_slaves = [
     LustreEC2Slave(
         name="CentOS-6.7-x86_64-buildslave%s" % (str(i+1)),
-        ami="ami-3c54165c"
+        ami="ami-0bd19c6b"
     ) for i in range(0, numSlaves)
 ]
 
 CentOS_7_2_slaves = [
     LustreEC2Slave(
         name="CentOS-7.2-x86_64-buildslave%s" % (str(i+1)),
-        ami="ami-89591be9"
+        ami="ami-92d19cf2"
     ) for i in range(0, numSlaves)
 ]
 
 Ubuntu_14_04_slaves = [
     LustreEC2Slave(
         name="Ubuntu-14.04-x86_64-buildslave%s" % (str(i+1)),
-        ami="ami-3d54165d"
+        ami="ami-48cc8128"
     ) for i in range(0, numSlaves)
 ]
 


### PR DESCRIPTION
Update to AMIs that have ZFS 0.6.5.7
pre-installed. Updated master.cfg to prevent
builders from cloning and building zfs.
This will speed up builds significantly.

Signed-off-by: Giuseppe Di Natale dinatale2@llnl.gov
