### PR TITLE
Add a CentOS 6.8 Builder

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -138,6 +138,13 @@ CentOS_6_7_slaves = [
     ) for i in range(0, numSlaves)
 ]
 
+CentOS_6_8_slaves = [
+    LustreEC2Slave(
+        name="CentOS-6.8-x86_64-buildslave%s" % (str(i+1)),
+        ami="ami-f3baf693"
+    ) for i in range(0, numSlaves)
+]
+
 CentOS_7_2_slaves = [
     LustreEC2Slave(
         name="CentOS-7.2-x86_64-buildslave%s" % (str(i+1)),
@@ -152,7 +159,7 @@ Ubuntu_14_04_slaves = [
     ) for i in range(0, numSlaves)
 ]
 
-all_slaves = CentOS_6_7_slaves + CentOS_7_2_slaves + Ubuntu_14_04_slaves + tarball_slaves
+all_slaves = CentOS_6_7_slaves + CentOS_6_8_slaves + CentOS_7_2_slaves + Ubuntu_14_04_slaves + tarball_slaves
 
 ### BUILDERS
 tarball_builders = [
@@ -171,14 +178,21 @@ builders = [
         factory=build_factory,
         slavenames=[slave.name for slave in CentOS_6_7_slaves],
         tags=["Build"],
-        properties=merge_dicts(default_props, {"distro" : "centos", "distrover" : "6", "arch" : "x86_64"}),
+        properties=merge_dicts(default_props, {"distro" : "centos", "distrover" : "6.7", "arch" : "x86_64"}),
+    ),
+    LustreBuilderConfig(
+        name="CentOS 6.8 x86_64 (BUILD)",
+        factory=build_factory,
+        slavenames=[slave.name for slave in CentOS_6_8_slaves],
+        tags=["Build"],
+        properties=merge_dicts(default_props, {"distro" : "centos", "distrover" : "6.8", "arch" : "x86_64"}),
     ),
     LustreBuilderConfig(
         name="CentOS 7.2 x86_64 (BUILD)",
         factory=build_factory,
         slavenames=[slave.name for slave in CentOS_7_2_slaves],
         tags=["Build"],
-        properties=merge_dicts(default_props, {"distro" : "centos", "distrover" : "7", "arch" : "x86_64"}),
+        properties=merge_dicts(default_props, {"distro" : "centos", "distrover" : "7.2", "arch" : "x86_64"}),
     ),
     LustreBuilderConfig(
         name="Ubuntu 14.04 x86_64 (BUILD)",


### PR DESCRIPTION
Ensure that Lustre builds against the CentOS 6.8
kernel.

Signed-off-by: Giuseppe Di Natale dinatale2@llnl.gov
