### PR TITLE
Clean up rpmbuild directories in /tmp

### DIFF
--- a/master/lustrefactory.py
+++ b/master/lustrefactory.py
@@ -378,7 +378,7 @@ def createPackageBuildFactory():
     # Cleanup
     bf.addStep(ShellCommand(
         workdir="build",
-        command=["sh", "-c", "rm -rvf *"],
+        command=["sh", "-c", "rm -rvf ./* /tmp/rpmbuild-*"],
         haltOnFailure=True,
         logEnviron=False,
         lazylogfiles=True,


### PR DESCRIPTION
Remove /tmp/rpmbuild-* directories in tmp. These
do not get cleaned up automatically on failure and can cause
build slaves to run out of disk space.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>