### PR TITLE
Enable install dependency step on builders

### DIFF
--- a/master/lustrefactory.py
+++ b/master/lustrefactory.py
@@ -222,6 +222,17 @@ def createTarballFactory(gerrit_repo):
         value=buildCategory, 
         hideStepIf=hide_except_error))
 
+    # update dependencies
+    bf.addStep(ShellCommand(
+        command=dependencyCommand,
+        decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
+        haltOnFailure=True,
+        logEnviron=False,
+        doStepIf=do_step_installdeps,
+        hideStepIf=hide_if_skipped,
+        description=["installing dependencies"],
+        descriptionDone=["installed dependencies"]))
+
     # Pull the patch from Gerrit
     bf.addStep(Gerrit(
         repourl=gerrit_repo,

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -77,7 +77,7 @@ def merge_dicts(*args):
 global_props = {
     "bburl"       :      bb_url,
     "bbmaster"    :      bb_master_url,
-    "installdeps" :      "no",
+    "installdeps" :      "yes",
     "buildzfs"    :      "no",
     "spltag"      :      "spl-0.6.5.7",
     "zfstag"      :      "zfs-0.6.5.7",


### PR DESCRIPTION
Install dependencies before building Lustre. This will
allow us to introduce new dependencies on the fly. Currently,
installing dependencies takes on the order of 30 secs.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>